### PR TITLE
[JENKINS-25887] - Don not follow symlinks in FullBackup

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/FullBackup.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/FullBackup.java
@@ -75,6 +75,7 @@ public class FullBackup extends FileManager {
     @Override
     public Iterable<File> getFilesToBackup() {
         DirectoryScanner directoryScanner = new DirectoryScanner(); // It will scan all files inside the root directory
+        directoryScanner.setFollowSymlinks(false);
         directoryScanner.setBasedir(baseDir);
         directoryScanner.setExcludes(Iterables.toArray(getExcludes(), String.class));
         directoryScanner.scan();


### PR DESCRIPTION
Backups shouldn't follow symbolic links.

I haven't been able to actually compile and test this change, because it uses out-of-date packages, and my various efforts to update various packages all ended in failure, when I discovered that the latest versions of some of the required packages use google-collections (which is obsolete and no longer maintained), and this package itself uses guava instead, and google-collections and guava are incompatible.

I don't know if anybody is maintaining this anymore. If so, then I think it needs some work to be compilable with an up-to-date java. My java mojo is not strong enough to get it done.
