### PR TITLE
Plugin facelift towards the 1.4 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.399</version>
+        <version>2.29</version>
     </parent>
 
     <artifactId>periodicbackup</artifactId>
@@ -37,11 +37,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version>
-        </dependency>
-        <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-archiver</artifactId>
             <version>2.2</version>
@@ -51,11 +46,6 @@
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
             <version>3.0.10</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>r05</version>
         </dependency>
         <dependency>
         	<groupId>org.hamcrest</groupId>
@@ -73,8 +63,11 @@
     </distributionManagement>
 
     <properties>
+        <!--For parent POM-->
+        <jenkins.version>1.609.3</jenkins.version>
+        <java.level>6</java.level>
+        
         <!-- define all plugin versions -->
-        <maven.version>3.0.1</maven.version>
         <maven-antrun-plugin.version>1.6</maven-antrun-plugin.version>
         <maven-assembly-plugin.version>2.2</maven-assembly-plugin.version>
         <maven-changelog-plugin.version>2.2</maven-changelog-plugin.version>
@@ -82,28 +75,17 @@
         <maven-clean-plugin.version>2.4.1</maven-clean-plugin.version>
         <maven-compiler-plugin.version>2.3.2</maven-compiler-plugin.version>
         <maven-dependency-plugin.version>2.1</maven-dependency-plugin.version>
-        <maven-deploy-plugin.version>2.5</maven-deploy-plugin.version>
         <maven-doap-plugin.version>1.0</maven-doap-plugin.version>
         <maven-eclipse-plugin.version>2.8</maven-eclipse-plugin.version>
-        <maven-enforcer-plugin.version>1.0</maven-enforcer-plugin.version>
         <maven-help-plugin.version>2.1.1</maven-help-plugin.version>
-        <maven-install-plugin.version>2.3.1</maven-install-plugin.version>
-        <maven-javadoc-plugin.version>2.7</maven-javadoc-plugin.version>
         <maven-jar-plugin.version>2.3.1</maven-jar-plugin.version>
-        <maven-jetty-plugin.version>6.1.26</maven-jetty-plugin.version>
         <maven-jxr-plugin.version>2.2</maven-jxr-plugin.version>
         <maven-pmd-plugin.version>2.5</maven-pmd-plugin.version>
         <maven-project-info-reports-plugin.version>2.3.1</maven-project-info-reports-plugin.version>
-        <maven-plugin-plugin.version>2.4.3</maven-plugin-plugin.version>
         <maven-reactor-plugin.version>1.0</maven-reactor-plugin.version>
-        <maven-release-plugin.version>2.1</maven-release-plugin.version>
         <maven-remote-resources-plugin.version>1.1</maven-remote-resources-plugin.version>
-        <maven-resources-plugin.version>2.4.3</maven-resources-plugin.version>
         <maven-site-plugin.version>2.1.1</maven-site-plugin.version>
         <maven-source-plugin.version>2.1.2</maven-source-plugin.version>
-        <maven-surefire-plugin.version>2.7.2</maven-surefire-plugin.version>
-        <maven-surefire-report-plugin.version>2.7.2</maven-surefire-report-plugin.version>
-        <maven-war-plugin.version>2.1.1</maven-war-plugin.version>
         <apt-maven-plugin.version>1.0-alpha-4</apt-maven-plugin.version>
         <axistools-maven-plugin.version>1.4</axistools-maven-plugin.version>
         <buildnumber-maven-plugin.version>1.0-beta-4</buildnumber-maven-plugin.version>
@@ -111,7 +93,6 @@
         <cargo-maven2-plugin.version>1.0.5</cargo-maven2-plugin.version>
         <cobertura-maven-plugin.version>2.4</cobertura-maven-plugin.version>
         <exec-maven-plugin.version>1.2</exec-maven-plugin.version>
-        <findbugs-maven-plugin.version>2.3.1</findbugs-maven-plugin.version>
         <gwt-maven-plugin.version>2.1.0-1</gwt-maven-plugin.version>
         <javancss-maven-plugin.version>2.0</javancss-maven-plugin.version>
         <jdepend-maven-plugin.version>2.0-beta-2</jdepend-maven-plugin.version>
@@ -160,20 +141,12 @@
                 <version>${maven-checkstyle-plugin.version}</version>
             </plugin>
             <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${maven-javadoc-plugin.version}</version>
-            </plugin>
-            <plugin>
                 <artifactId>maven-jxr-plugin</artifactId>
                 <version>${maven-jxr-plugin.version}</version>
             </plugin>
             <plugin>
                 <artifactId>maven-pmd-plugin</artifactId>
                 <version>${maven-pmd-plugin.version}</version>
-            </plugin>
-            <plugin>
-                <artifactId>maven-plugin-plugin</artifactId>
-                <version>${maven-plugin-plugin.version}</version>
             </plugin>
             <plugin>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
@@ -195,18 +168,9 @@
                 </reportSets>
             </plugin>
             <plugin>
-                <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>${maven-surefire-report-plugin.version}</version>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
                 <version>${cobertura-maven-plugin.version}</version>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>${findbugs-maven-plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,39 +66,6 @@
         <!--For parent POM-->
         <jenkins.version>1.609.3</jenkins.version>
         <java.level>6</java.level>
-        
-        <!-- define all plugin versions -->
-        <maven-antrun-plugin.version>1.6</maven-antrun-plugin.version>
-        <maven-assembly-plugin.version>2.2</maven-assembly-plugin.version>
-        <maven-changelog-plugin.version>2.2</maven-changelog-plugin.version>
-        <maven-checkstyle-plugin.version>2.6</maven-checkstyle-plugin.version>
-        <maven-clean-plugin.version>2.4.1</maven-clean-plugin.version>
-        <maven-compiler-plugin.version>2.3.2</maven-compiler-plugin.version>
-        <maven-doap-plugin.version>1.0</maven-doap-plugin.version>
-        <maven-eclipse-plugin.version>2.8</maven-eclipse-plugin.version>
-        <maven-help-plugin.version>2.1.1</maven-help-plugin.version>
-        <maven-jar-plugin.version>2.3.1</maven-jar-plugin.version>
-        <maven-jxr-plugin.version>2.2</maven-jxr-plugin.version>
-        <maven-pmd-plugin.version>2.5</maven-pmd-plugin.version>
-        <maven-project-info-reports-plugin.version>2.3.1</maven-project-info-reports-plugin.version>
-        <maven-reactor-plugin.version>1.0</maven-reactor-plugin.version>
-        <maven-remote-resources-plugin.version>1.1</maven-remote-resources-plugin.version>
-        <maven-site-plugin.version>2.1.1</maven-site-plugin.version>
-        <maven-source-plugin.version>2.1.2</maven-source-plugin.version>
-        <apt-maven-plugin.version>1.0-alpha-4</apt-maven-plugin.version>
-        <axistools-maven-plugin.version>1.4</axistools-maven-plugin.version>
-        <buildnumber-maven-plugin.version>1.0-beta-4</buildnumber-maven-plugin.version>
-        <build-helper-maven-plugin.version>1.5</build-helper-maven-plugin.version>
-        <cargo-maven2-plugin.version>1.0.5</cargo-maven2-plugin.version>
-        <cobertura-maven-plugin.version>2.4</cobertura-maven-plugin.version>
-        <exec-maven-plugin.version>1.2</exec-maven-plugin.version>
-        <gwt-maven-plugin.version>2.1.0-1</gwt-maven-plugin.version>
-        <javancss-maven-plugin.version>2.0</javancss-maven-plugin.version>
-        <jdepend-maven-plugin.version>2.0-beta-2</jdepend-maven-plugin.version>
-        <openjpa-maven-plugin.version>1.2</openjpa-maven-plugin.version>
-        <taglist-maven-plugin.version>2.4</taglist-maven-plugin.version>
-        <versions-maven-plugin.version>1.2</versions-maven-plugin.version>
-        <xml-maven-plugin.version>1.0-beta-3</xml-maven-plugin.version>
     </properties>
 
     <build>
@@ -119,37 +86,35 @@
                 <version>0.3.1</version>
             </extension>
         </extensions>
-        <!-- ... rest of your build section ... -->
         <plugins>
             <plugin>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>${maven-site-plugin.version}</version>
+                <version>2.1.1</version>
             </plugin>
         </plugins>
-        <!-- ... rest of your build section ... -->
     </build>
 
     <reporting>
         <plugins>
             <plugin>
                 <artifactId>maven-changelog-plugin</artifactId>
-                <version>${maven-changelog-plugin.version}</version>
+                <version>2.2</version>
             </plugin>
             <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>${maven-checkstyle-plugin.version}</version>
+                <version>2.6</version>
             </plugin>
             <plugin>
                 <artifactId>maven-jxr-plugin</artifactId>
-                <version>${maven-jxr-plugin.version}</version>
+                <version>2.2</version>
             </plugin>
             <plugin>
                 <artifactId>maven-pmd-plugin</artifactId>
-                <version>${maven-pmd-plugin.version}</version>
+                <version>2.5</version>
             </plugin>
             <plugin>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>${maven-project-info-reports-plugin.version}</version>
+                <version>2.3.1</version>
                 <reportSets>
                     <reportSet>
                         <reports>
@@ -169,27 +134,25 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
-                <version>${cobertura-maven-plugin.version}</version>
+                <version>2.4</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>javancss-maven-plugin</artifactId>
-                <version>${javancss-maven-plugin.version}</version>
+                <version>2.0</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>jdepend-maven-plugin</artifactId>
-                <version>${jdepend-maven-plugin.version}</version>
+                <version>2.0-beta-2</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>taglist-maven-plugin</artifactId>
-                <version>${taglist-maven-plugin.version}</version>
+                <version>2.4</version>
             </plugin>
         </plugins>
     </reporting>
-
-
 
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -73,12 +73,12 @@
             <extension>
                 <groupId>org.apache.maven.scm</groupId>
                 <artifactId>maven-scm-provider-gitexe</artifactId>
-                <version>1.3</version>
+                <version>1.9.5</version>
             </extension>
             <extension>
                 <groupId>org.apache.maven.scm</groupId>
                 <artifactId>maven-scm-manager-plexus</artifactId>
-                <version>1.3</version>
+                <version>1.9.5</version>
             </extension>
             <extension>
                 <groupId>org.kathrynhuxtable.maven.wagon</groupId>
@@ -87,34 +87,35 @@
             </extension>
         </extensions>
         <plugins>
-            <plugin>
-                <artifactId>maven-site-plugin</artifactId>
-                <version>2.1.1</version>
-            </plugin>
+          <plugin>
+            <artifactId>maven-site-plugin</artifactId>
+            <version>3.6</version>
+          </plugin>
         </plugins>
+        
     </build>
 
     <reporting>
         <plugins>
             <plugin>
                 <artifactId>maven-changelog-plugin</artifactId>
-                <version>2.2</version>
+                <version>2.3</version>
             </plugin>
             <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.6</version>
+                <version>2.17</version>
             </plugin>
             <plugin>
                 <artifactId>maven-jxr-plugin</artifactId>
-                <version>2.2</version>
-            </plugin>
-            <plugin>
-                <artifactId>maven-pmd-plugin</artifactId>
                 <version>2.5</version>
             </plugin>
             <plugin>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>3.8</version>
+            </plugin>
+            <plugin>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>2.9</version>
                 <reportSets>
                     <reportSet>
                         <reports>
@@ -133,18 +134,19 @@
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
+                <!-- TODO: Pick 2.7+ once MCOBERTURA-203 is fixed -->
                 <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.4</version>
+                <version>2.6</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>javancss-maven-plugin</artifactId>
-                <version>2.0</version>
+                <version>2.1</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>jdepend-maven-plugin</artifactId>
-                <version>2.0-beta-2</version>
+                <version>2.0</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,6 @@
         <maven-checkstyle-plugin.version>2.6</maven-checkstyle-plugin.version>
         <maven-clean-plugin.version>2.4.1</maven-clean-plugin.version>
         <maven-compiler-plugin.version>2.3.2</maven-compiler-plugin.version>
-        <maven-dependency-plugin.version>2.1</maven-dependency-plugin.version>
         <maven-doap-plugin.version>1.0</maven-doap-plugin.version>
         <maven-eclipse-plugin.version>2.8</maven-eclipse-plugin.version>
         <maven-help-plugin.version>2.1.1</maven-help-plugin.version>

--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/BackupObject.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/BackupObject.java
@@ -27,12 +27,12 @@ package org.jenkinsci.plugins.periodicbackup;
 import com.google.common.base.Function;
 import com.google.common.base.Objects;
 import com.google.common.io.Files;
-import hudson.model.Hudson;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Date;
+import jenkins.model.Jenkins;
 
 public class BackupObject implements Comparable {
 
@@ -75,7 +75,7 @@ public class BackupObject implements Comparable {
             public BackupObject apply(File file) {
                 if(file != null) {
                     try {
-                        return (BackupObject) Hudson.XSTREAM.fromXML(Files.toString(file, Charset.defaultCharset()));
+                        return (BackupObject) Jenkins.XSTREAM.fromXML(Files.toString(file, Charset.defaultCharset()));
                     } catch (IOException e) {
                         return null;
                     }
@@ -94,7 +94,7 @@ public class BackupObject implements Comparable {
         return new Function<String, BackupObject>() {
             public BackupObject apply(String content) {
                 if (content != null) {
-                    return (BackupObject) Hudson.XSTREAM.fromXML(content);
+                    return (BackupObject) Jenkins.XSTREAM.fromXML(content);
                 } else {
                     return null;
                 }
@@ -113,7 +113,7 @@ public class BackupObject implements Comparable {
     }
 
     public String getAsString() {
-        return Hudson.XSTREAM.toXML(this);
+        return Jenkins.XSTREAM.toXML(this);
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/BackupObject.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/BackupObject.java
@@ -27,12 +27,15 @@ package org.jenkinsci.plugins.periodicbackup;
 import com.google.common.base.Function;
 import com.google.common.base.Objects;
 import com.google.common.io.Files;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Date;
 import jenkins.model.Jenkins;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 public class BackupObject implements Comparable {
 
@@ -48,7 +51,7 @@ public class BackupObject implements Comparable {
         this.fileManager = fileManager;
         this.storage = storage;
         this.location = location;
-        this.timestamp = timestamp;
+        this.timestamp = timestamp != null ? (Date)timestamp.clone() : null;
     }
 
     @SuppressWarnings("unused")
@@ -70,6 +73,7 @@ public class BackupObject implements Comparable {
      *
      * @return transformation function to convert BackupObject file into BackupObject
      */
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "As designed in API")
     public static Function<File, BackupObject> getFromFile() {
         return new Function<File, BackupObject>() {
             public BackupObject apply(File file) {
@@ -103,6 +107,8 @@ public class BackupObject implements Comparable {
     }
 
     @SuppressWarnings("unused")
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "Internal API")
+    @Restricted(NoExternalUse.class)
     public Date getTimestamp() {
         return this.timestamp;
     }

--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/ConfigOnly.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/ConfigOnly.java
@@ -36,6 +36,7 @@ import java.io.FileFilter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
+import jenkins.model.Jenkins;
 
 /**
  *
@@ -59,7 +60,7 @@ public class ConfigOnly extends FileManager {
 
     @Override
     public Iterable<File> getFilesToBackup() throws PeriodicBackupException {
-        File rootDir = Hudson.getInstance().getRootDir();
+        File rootDir = Jenkins.getActiveInstance().getRootDir();
         List<File> filesToBackup = Lists.newArrayList();
         addRootFiles(rootDir, filesToBackup);
         addJobFiles(rootDir, filesToBackup);

--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/ConfigOnly.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/ConfigOnly.java
@@ -112,12 +112,7 @@ public class ConfigOnly extends FileManager {
         File usersDir = new File(rootDir, "users");
         if (usersDir.exists() && usersDir.isDirectory()) {
             // Each user directory should have a config.xml file
-            File[] dirsInUsers = usersDir.listFiles((FileFilter) FileFilterUtils.directoryFileFilter());
-            if (dirsInUsers == null) {
-                // First one may happen only due to the race condition
-                throw new PeriodicBackupException("Job directory path does not denote or there is an I/O error");
-            }
-            
+            File[] dirsInUsers =  Util.listFiles(usersDir, FileFilterUtils.directoryFileFilter());
             for (File user : dirsInUsers) {
                 File userConfig = new File(user, "config.xml");
                 if (userConfig.exists() && userConfig.isFile()) {

--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/FileManager.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/FileManager.java
@@ -28,10 +28,10 @@ import com.google.common.base.Objects;
 import hudson.DescriptorExtensionList;
 import hudson.model.AbstractModelObject;
 import hudson.model.Describable;
-import hudson.model.Hudson;
 
 import java.io.File;
 import java.io.IOException;
+import jenkins.model.Jenkins;
 
 /**
  *
@@ -68,13 +68,14 @@ public abstract class FileManager extends AbstractModelObject implements Describ
      * @return Collection of FileManager Descriptors
      */
     public static DescriptorExtensionList<FileManager, FileManagerDescriptor> all() {
-        return Hudson.getInstance().getDescriptorList(FileManager.class);
+        return Jenkins.getActiveInstance().getDescriptorList(FileManager.class);
     }
 
     public FileManagerDescriptor getDescriptor() {
-        return (FileManagerDescriptor) Hudson.getInstance().getDescriptor(getClass());
+        return (FileManagerDescriptor) Jenkins.getActiveInstance().getDescriptor(getClass());
     }
 
+    @Override
     public String getSearchUrl() {
         return "FileManager";
     }

--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/FullBackup.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/FullBackup.java
@@ -29,13 +29,13 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import hudson.Extension;
-import hudson.model.Hudson;
 import org.apache.tools.ant.DirectoryScanner;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
+import jenkins.model.Jenkins;
 
 
 /**
@@ -51,7 +51,7 @@ public class FullBackup extends FileManager {
 
     @DataBoundConstructor
 	public FullBackup(String excludesString) {
-		this(excludesString, Hudson.getInstance().getRootDir());
+		this(excludesString, Jenkins.getActiveInstance().getRootDir());
 	}
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/FullBackup.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/FullBackup.java
@@ -35,7 +35,10 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
+import org.apache.commons.lang.StringUtils;
 
 
 /**
@@ -46,23 +49,28 @@ import jenkins.model.Jenkins;
  */
 public class FullBackup extends FileManager {
 	
-	private final String excludesString;
+    @CheckForNull
+    private final String excludesString;
 	private final File baseDir;
 
+    public FullBackup() {
+        this(null);
+    }
+
     @DataBoundConstructor
-	public FullBackup(String excludesString) {
+	public FullBackup(@CheckForNull String excludesString) {
 		this(excludesString, Jenkins.getActiveInstance().getRootDir());
 	}
 
     /**
      * Test Constructor
      * 
-     * @param excludesString
-     * @param baseDir
+     * @param excludesString Optional list of directories to be excluded
+     * @param baseDir Base directory
      */
-    FullBackup(String excludesString, File baseDir) {
+    FullBackup(@CheckForNull String excludesString, @Nonnull File baseDir) {
     	super();
-    	this.excludesString = excludesString;
+    	this.excludesString = StringUtils.trimToNull(excludesString);
 		this.baseDir = baseDir;
     	this.restorePolicy = new ReplaceRestorePolicy();
     }
@@ -107,9 +115,10 @@ public class FullBackup extends FileManager {
         return 73;
     }	
     
+    @CheckForNull
     public String getExcludesString() {
-		return excludesString;
-	}
+        return excludesString;
+    }
 
     @SuppressWarnings("unused")
     @Extension

--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/LocalDirectory.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/LocalDirectory.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -64,10 +65,19 @@ public class LocalDirectory extends Location {
             LOGGER.warning(path.getAbsolutePath() + " is not a existing/writable directory.");
             return Sets.newHashSet();
         }
-        if(path.listFiles().length == 0) {
+        
+        FileFilter extensionFileFilter = Util.extensionFileFilter(BackupObject.EXTENSION);
+        final File[] files;
+        try {
+            files = Util.listFiles(path, extensionFileFilter);
+        } catch(PeriodicBackupException ex) {
+            LOGGER.log(Level.WARNING, "Cannot retrieve extension files from " + path.getAbsolutePath(), ex);
             return Sets.newHashSet();
         }
-        File[] files = path.listFiles(Util.extensionFileFilter(BackupObject.EXTENSION));
+        
+        if(files.length == 0) {
+            return Sets.newHashSet();
+        }
         List<File> backupObjectFiles = Lists.newArrayList(files);
         // The sorting will be performed according to the timestamp
         Collections.sort(backupObjectFiles);
@@ -100,7 +110,7 @@ public class LocalDirectory extends Location {
     @Override
     public Iterable<File> retrieveBackupFromLocation(final BackupObject backup, File tempDir) throws IOException, PeriodicBackupException {
         // Get the list of archive files related to the given BackupObject
-        File[] files = path.listFiles(new FileFilter() {
+        File[] files = Util.listFiles(path, new FileFilter() {
             public boolean accept(File pathname) {
                 return (pathname.getName().contains( Util.getFormattedDate(BackupObject.FILE_TIMESTAMP_PATTERN, backup.getTimestamp())) &&
                         !pathname.getName().endsWith(BackupObject.EXTENSION));
@@ -141,7 +151,13 @@ public class LocalDirectory extends Location {
     @Override
     public void deleteBackupFiles(BackupObject backupObject) {
         String filenamePart = Util.generateFileNameBase(backupObject.getTimestamp());
-        File[] files = path.listFiles();
+        final File[] files;
+        try {
+            files = Util.listFiles(path);
+        } catch (PeriodicBackupException ex) {
+            LOGGER.log(Level.WARNING, "Cannot enumerate the backup files", ex);
+            return;
+        }
 
         // Delete all the files containing the timestamp of the given BackupObject in their names
         for(File file : files) {

--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/Location.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/Location.java
@@ -27,10 +27,10 @@ package org.jenkinsci.plugins.periodicbackup;
 import hudson.DescriptorExtensionList;
 import hudson.model.AbstractModelObject;
 import hudson.model.Describable;
-import hudson.model.Hudson;
 
 import java.io.File;
 import java.io.IOException;
+import jenkins.model.Jenkins;
 
 /**
  *
@@ -87,13 +87,15 @@ public abstract class Location extends AbstractModelObject implements Describabl
      * @return Collection of FileManager Descriptors
      */
     public static DescriptorExtensionList<Location, LocationDescriptor> all() {
-        return Hudson.getInstance().getDescriptorList(Location.class);
+        return Jenkins.getActiveInstance().getDescriptorList(Location.class);
     }
 
+    @Override
     public LocationDescriptor getDescriptor() {
-        return (LocationDescriptor) Hudson.getInstance().getDescriptor(getClass());
+        return (LocationDescriptor) Jenkins.getActiveInstance().getDescriptor(getClass());
     }
 
+    @Override
     public String getSearchUrl() {
         return "Location";
     }

--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/NullStorage.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/NullStorage.java
@@ -26,13 +26,13 @@ package org.jenkinsci.plugins.periodicbackup;
 
 import com.google.common.collect.Lists;
 import hudson.Extension;
-import hudson.model.Hudson;
 import org.apache.commons.io.FileUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.logging.Logger;
+import jenkins.model.Jenkins;
 
 public class NullStorage extends Storage {
 
@@ -63,7 +63,7 @@ public class NullStorage extends Storage {
     public void backupAddFile(File fileToStore) throws PeriodicBackupException {
         try {
             FileUtils.copyFile(fileToStore, new File(destinationDirectory,
-                    Util.getRelativePath(fileToStore, Hudson.getInstance().getRootDir())));
+                    Util.getRelativePath(fileToStore, Jenkins.getActiveInstance().getRootDir())));
         } catch (IOException e) {
             LOGGER.warning("Could not copy " + fileToStore.getAbsolutePath() + " to " + destinationDirectory);
         }

--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/OverwriteRestorePolicy.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/OverwriteRestorePolicy.java
@@ -24,12 +24,12 @@
 
 package org.jenkinsci.plugins.periodicbackup;
 
-import hudson.model.Hudson;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.logging.Logger;
+import jenkins.model.Jenkins;
 
 /**
  *
@@ -41,7 +41,7 @@ public class OverwriteRestorePolicy implements RestorePolicy {
     private static final Logger LOGGER = Logger.getLogger(OverwriteRestorePolicy.class.getName());
 
     public void restore(File tempDir) throws IOException {
-        File hudsonRoot = Hudson.getInstance().getRootDir();
+        File hudsonRoot = Jenkins.getActiveInstance().getRootDir();
 
         FileUtils.copyDirectory(tempDir, hudsonRoot);
         LOGGER.info("Restoring of files finished");

--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/PeriodicBackupException.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/PeriodicBackupException.java
@@ -28,4 +28,8 @@ class PeriodicBackupException extends Exception {
     public PeriodicBackupException(String msg) {
         super(msg);
     }
+    
+    public PeriodicBackupException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/PeriodicBackupLink.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/PeriodicBackupLink.java
@@ -226,7 +226,7 @@ public class PeriodicBackupLink extends ManagementLink implements Describable<Pe
     }
 
     public DescriptorImpl getDescriptor() {
-        return Hudson.getInstance().getDescriptorByType(DescriptorImpl.class);
+        return Jenkins.getActiveInstance().getDescriptorByType(DescriptorImpl.class);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/PeriodicBackupLink.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/PeriodicBackupLink.java
@@ -44,6 +44,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
+import jenkins.model.Jenkins;
 
 /**
  *
@@ -192,12 +193,12 @@ public class PeriodicBackupLink extends ManagementLink implements Describable<Pe
 
     protected XmlFile getConfigXml() {
         return new XmlFile(Hudson.XSTREAM,
-                new File(Hudson.getInstance().getRootDir(), "periodicBackup.xml"));
+                new File(Jenkins.getActiveInstance().getRootDir(), "periodicBackup.xml"));
     }
 
     @SuppressWarnings("unused")
     public String getRootDirectory() {
-        return Hudson.getInstance().getRootDir().getAbsolutePath();
+        return Jenkins.getActiveInstance().getRootDir().getAbsolutePath();
     }
 
     @SuppressWarnings("unused")

--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/PeriodicBackupPlugin.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/PeriodicBackupPlugin.java
@@ -71,7 +71,7 @@ public class PeriodicBackupPlugin extends Plugin {
 
         // Find Target with the specified name according to LogRecorder.
         Target target = null;
-        if ((recorder != null) && (current != null)) {
+        if (current != null) {
           for (Target currTarg : recorder.targets) {
             if (currTarg.name.equals(current)) {
               target = currTarg;

--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/PeriodicBackupPlugin.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/PeriodicBackupPlugin.java
@@ -3,11 +3,11 @@ package org.jenkinsci.plugins.periodicbackup;
 import hudson.Plugin;
 import hudson.logging.LogRecorder;
 import hudson.logging.LogRecorder.Target;
-import hudson.model.Hudson;
 import hudson.security.ACL;
 
 import java.io.IOException;
 import java.util.logging.Level;
+import jenkins.model.Jenkins;
 
 import org.acegisecurity.Authentication;
 import org.acegisecurity.context.SecurityContextHolder;
@@ -53,11 +53,11 @@ public class PeriodicBackupPlugin extends Plugin {
 
     try {
       for (String current : debugLoggerNames) {
-        LogRecorder recorder = Hudson.getInstance().getLog().getLogRecorder(current);
+        LogRecorder recorder = Jenkins.getActiveInstance().getLog().getLogRecorder(current);
 
         if (recorder == null) {
-          Hudson.getInstance().getLog().doNewLogRecorder(current);
-          recorder = Hudson.getInstance().getLog().getLogRecorder(current);
+          Jenkins.getActiveInstance().getLog().doNewLogRecorder(current);
+          recorder = Jenkins.getActiveInstance().getLog().getLogRecorder(current);
           recorder.targets.add(new Target(current, level));
 
           try {

--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/ReplaceRestorePolicy.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/ReplaceRestorePolicy.java
@@ -25,13 +25,13 @@
 package org.jenkinsci.plugins.periodicbackup;
 
 import com.google.common.collect.Lists;
-import hudson.model.Hudson;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.logging.Logger;
+import jenkins.model.Jenkins;
 
 /**
  *
@@ -46,7 +46,7 @@ public class ReplaceRestorePolicy implements RestorePolicy {
     private transient int filesDeleted, filesReplaced, filesKept;
 
     public void restore(File tempDir) throws IOException, PeriodicBackupException {
-        hudsonRoot = Hudson.getInstance().getRootDir();
+        hudsonRoot = Jenkins.getActiveInstance().getRootDir();
         if(hudsonRoot == null) {
             throw new PeriodicBackupException("HOME directory is unidentified.");
         }

--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/ReplaceRestorePolicy.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/ReplaceRestorePolicy.java
@@ -122,7 +122,7 @@ public class ReplaceRestorePolicy implements RestorePolicy {
                     FileUtils.copyFile(file, destinationFile);
                     filesReplaced++;
                 }
-                else if(autoExclusionList != null && autoExclusionList.contains(relativePath)) {
+                else if(autoExclusionList.contains(relativePath)) {
                         LOGGER.warning("File " + file.getAbsolutePath() + " is excluded from the restore process, original file will be kept");
                         filesKept++;
                 }

--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/ReplaceRestorePolicy.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/ReplaceRestorePolicy.java
@@ -31,6 +31,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.logging.Logger;
+import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
 
 /**
@@ -55,9 +56,9 @@ public class ReplaceRestorePolicy implements RestorePolicy {
         filesReplaced = 0;
         filesKept = 0;
 
-        deleteAccessible(hudsonRoot.listFiles());
+        deleteAccessible(Util.listFiles(hudsonRoot));
         LOGGER.info(filesDeleted + " files have been deleted from " + hudsonRoot.getAbsolutePath());
-        replaceAccessible(tempDir.listFiles(), tempDir);
+        replaceAccessible(Util.listFiles(tempDir), tempDir);
         LOGGER.info("Replacing of files finished.\nAfter deleting " + filesDeleted + " files from " +
                 hudsonRoot.getAbsolutePath() + "\n" + filesReplaced + " files have been restored from backup and "
                 + filesKept + " files have been kept.");
@@ -68,8 +69,9 @@ public class ReplaceRestorePolicy implements RestorePolicy {
      * Attempt to recursively delete all accessible files from the given files array.
      *
      * @param files array of File objects given in order to be deleted
+     * @throws PeriodicBackupException Issue with listing one of the child directories
      */
-    private void deleteAccessible(File[] files) {
+    private void deleteAccessible(@Nonnull File[] files) throws PeriodicBackupException {
         String relativePath;
         for(File file : files) {
             if(!file.isDirectory()) {
@@ -90,7 +92,7 @@ public class ReplaceRestorePolicy implements RestorePolicy {
                 }
             }
             else {
-                deleteAccessible(file.listFiles());
+                deleteAccessible(Util.listFiles(file));
             }
         }
     }
@@ -103,8 +105,9 @@ public class ReplaceRestorePolicy implements RestorePolicy {
      * @param files to copy
      * @param tempDir temporary directory where @files are placed
      * @throws IOException If an IO problem occurs
+     * @throws PeriodicBackupException Issue with listing one of the directories
      */
-    private void replaceAccessible(File[] files, File tempDir) throws IOException {
+    private void replaceAccessible(File[] files, File tempDir) throws IOException, PeriodicBackupException {
         String relativePath;
         File destinationFile;
         for(File file : files) {
@@ -125,7 +128,7 @@ public class ReplaceRestorePolicy implements RestorePolicy {
                 }
             }
             else {
-                replaceAccessible(file.listFiles(), tempDir);
+                replaceAccessible(Util.listFiles(file), tempDir);
             }
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/RestoreExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/RestoreExecutor.java
@@ -64,7 +64,15 @@ public class RestoreExecutor implements Runnable {
         File finalResultDir = new File(tempDir, "finalResult");
 
         // The /finalResult directory should be empty at this point
-        File[] finalResultDirFileList = finalResultDir.listFiles();
+        File[] finalResultDirFileList;
+        try {
+            finalResultDirFileList = Util.listFiles(finalResultDir);
+        } catch (PeriodicBackupException ex) {
+            LOGGER.log(Level.WARNING, "Restoration Failure! Cannot list contents of " + finalResultDir.getAbsolutePath(), ex);
+            PeriodicBackupLink.get().setMessage("");
+            return;
+        }
+        
         if(finalResultDir.exists() && finalResultDirFileList.length > 0) {
             LOGGER.warning("The final result directory " + finalResultDir.getAbsolutePath() + " is not empty, deleting...");
             try {

--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/RestoreExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/RestoreExecutor.java
@@ -24,7 +24,6 @@
 
 package org.jenkinsci.plugins.periodicbackup;
 
-import hudson.model.Hudson;
 import hudson.security.ACL;
 import org.acegisecurity.Authentication;
 import org.acegisecurity.context.SecurityContextHolder;
@@ -34,6 +33,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import jenkins.model.Jenkins;
 
 public class RestoreExecutor implements Runnable {
 
@@ -107,7 +107,7 @@ public class RestoreExecutor implements Runnable {
         Authentication origAuth = SecurityContextHolder.getContext().getAuthentication();
         SecurityContextHolder.getContext().setAuthentication(ACL.SYSTEM);
         try {
-            Hudson.getInstance().doReload();
+            Jenkins.getActiveInstance().doReload();
         } catch (IOException e) {
             LOGGER.log(Level.WARNING, "Error reloading config files from disk: {0}", e.getMessage());
         } finally {

--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/Storage.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/Storage.java
@@ -27,9 +27,9 @@ package org.jenkinsci.plugins.periodicbackup;
 import hudson.DescriptorExtensionList;
 import hudson.model.AbstractModelObject;
 import hudson.model.Describable;
-import hudson.model.Hudson;
 
 import java.io.File;
+import jenkins.model.Jenkins;
 
 /**
  *
@@ -76,7 +76,7 @@ public abstract class Storage extends AbstractModelObject implements Describable
     public abstract void unarchiveFiles(Iterable<File> archives, File finalResultDir);
 
     public StorageDescriptor getDescriptor() {
-        return (StorageDescriptor) Hudson.getInstance().getDescriptor(getClass());
+        return (StorageDescriptor) Jenkins.getActiveInstance().getDescriptor(getClass());
     }
 
     public String getSearchUrl() {
@@ -90,7 +90,7 @@ public abstract class Storage extends AbstractModelObject implements Describable
      * @return Collection of FileManager Descriptors
      */
     public static DescriptorExtensionList<Storage, StorageDescriptor> all() {
-        return Hudson.getInstance().getDescriptorList(Storage.class);
+        return Jenkins.getActiveInstance().getDescriptorList(Storage.class);
     }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/TarGzStorage.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/TarGzStorage.java
@@ -26,7 +26,6 @@ package org.jenkinsci.plugins.periodicbackup;
 
 import com.google.common.collect.Lists;
 import hudson.Extension;
-import hudson.model.Hudson;
 import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.archiver.tar.TarArchiver;
 import org.codehaus.plexus.archiver.tar.TarGZipUnArchiver;
@@ -37,6 +36,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import java.io.File;
 import java.io.IOException;
 import java.util.logging.Logger;
+import jenkins.model.Jenkins;
 
 public class TarGzStorage extends Storage {
 
@@ -76,7 +76,7 @@ public class TarGzStorage extends Storage {
     @Override
     public void backupAddFile(File fileToStore) throws PeriodicBackupException {
         try {
-            archiver.addFile(fileToStore, Util.getRelativePath(fileToStore, Hudson.getInstance().getRootDir()));
+            archiver.addFile(fileToStore, Util.getRelativePath(fileToStore, Jenkins.getActiveInstance().getRootDir()));
         } catch (ArchiverException e) {
             LOGGER.warning("Could not add file to the archive. " + e.getMessage());
         }

--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/Util.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/Util.java
@@ -183,7 +183,7 @@ public class Util {
         try {
             files = fileFilter == null ? directory.listFiles() : directory.listFiles(fileFilter);
         } catch(SecurityException ex) {
-            throw new PeriodicBackupException(formatMessage(directory, "Securiy exception while listing files"), ex);
+            throw new PeriodicBackupException(formatMessage(directory, "Security exception while listing files"), ex);
         }
         
         if (files == null) {

--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/ZipStorage.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/ZipStorage.java
@@ -26,7 +26,6 @@ package org.jenkinsci.plugins.periodicbackup;
 
 import com.google.common.collect.Sets;
 import hudson.Extension;
-import hudson.model.Hudson;
 import net.sf.json.JSONObject;
 import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.archiver.zip.ZipArchiver;
@@ -39,6 +38,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 import java.util.logging.Logger;
+import jenkins.model.Jenkins;
 
 public class ZipStorage extends Storage {
 
@@ -183,7 +183,7 @@ public class ZipStorage extends Storage {
      */
     private void addFile(File fileToStore) {
         try {
-            archiver.addFile(fileToStore, Util.getRelativePath(fileToStore, Hudson.getInstance().getRootDir()));
+            archiver.addFile(fileToStore, Util.getRelativePath(fileToStore, Jenkins.getActiveInstance().getRootDir()));
             currentArchiveFilesCount++;
             currentArchiveTotalFilesSize += fileToStore.length();
         } catch (ArchiverException e) {

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -22,6 +22,7 @@
   - THE SOFTWARE.
   -->
 
+<?jelly escape-by-default='true'?>
 <div>
     Backup or restore your Jenkins configuration files
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/periodicbackup/ConfigOnly/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/periodicbackup/ConfigOnly/config.jelly
@@ -25,6 +25,7 @@
 <!--
   ConfigOnly config page
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 

--- a/src/main/resources/org/jenkinsci/plugins/periodicbackup/FullBackup/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/periodicbackup/FullBackup/config.jelly
@@ -25,6 +25,7 @@
 <!--
   FullBackup config page
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 

--- a/src/main/resources/org/jenkinsci/plugins/periodicbackup/LocalDirectory/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/periodicbackup/LocalDirectory/config.jelly
@@ -25,6 +25,7 @@
 <!--
   LocalDirectory config page
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 

--- a/src/main/resources/org/jenkinsci/plugins/periodicbackup/PeriodicBackupLink/configure.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/periodicbackup/PeriodicBackupLink/configure.jelly
@@ -25,6 +25,7 @@
 <!--
   Config page
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
     <l:layout norefresh="true" title="${%Periodic Backup Configuration}">

--- a/src/main/resources/org/jenkinsci/plugins/periodicbackup/PeriodicBackupLink/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/periodicbackup/PeriodicBackupLink/index.jelly
@@ -21,7 +21,7 @@
   - OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   - THE SOFTWARE.
   -->
-
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <l:layout norefresh="true" title="${%periodicBackupConfiguration.title}">

--- a/src/main/resources/org/jenkinsci/plugins/periodicbackup/PeriodicBackupLink/sidepanel.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/periodicbackup/PeriodicBackupLink/sidepanel.jelly
@@ -21,7 +21,7 @@
   - OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   - THE SOFTWARE.
   -->
-
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
     <l:header/>

--- a/src/main/resources/org/jenkinsci/plugins/periodicbackup/ZipStorage/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/periodicbackup/ZipStorage/config.jelly
@@ -25,6 +25,7 @@
 <!--
   ZipStorage config page
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:block>


### PR DESCRIPTION
This change updates the plugin to the newer parent POM towards the 1.4 release. There was no updates for a long time, hence there are pretty much changes to be done.

- [x] - Update the minimal Jenkins core version to 1.609.3 - the last version with Java 6 support
- [x] - Update to Parent POM 2.x
- [x] - Cleanup FindBugs issues. There are valid ones in the file listing logic
- [x] - Escape all Jelly files by default
- [x] - Fix binary incompatibility introduces in non-released changes
- [x] - Cleanup some ancient plugin definitions (probably others can be cleaned up as well)
- [x] - Get rid of ancient dependencies explicitly defined in POM
- [x] - Make `mvn site` really working with Maven 3

@reviewbybees, cc @svanoort who was looking at this code before
