### PR TITLE
[JENKINS-44997] - Do not use table in BeriodicBackupLink submission form

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/periodicbackup/PeriodicBackupLink/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/periodicbackup/PeriodicBackupLink/index.jelly
@@ -38,28 +38,29 @@
                 </j:when>
                 <j:otherwise>
                     <h3>Locations:</h3>
-                        <f:form method="post" action="restore">
-                            <j:set var="noBackups" value="true"/>
-                            <j:forEach var="location" items="${it.locations}">
-                                <div>
-                                    <h4>${location.displayName}</h4>
-                                        <table>
-                                            <j:forEach var="backup" items="${location.availableBackups}">
-                                                <tr>
-                                                    <td><f:radio name="backupHash" value="${backup.hashCode()}"/></td>
-                                                    <td>${backup.displayName}</td>
-                                                <j:set var="noBackups" value="false"/>
-                                                </tr>
-                                            </j:forEach>
-                                        </table>
-                                    </div>
-                            </j:forEach>
-                            <div style="padding:4px">
-                                <j:if test="${noBackups == 'false'}">
-                                    <f:submit value="${%restore.launch}"/>
-                                </j:if>
-                            </div>
-                        </f:form>
+                    <f:form method="post" action="restore">
+                      <j:set var="noBackups" value="true"/>
+                      <j:forEach var="location" items="${it.locations}">
+                        <div>
+                          <h4>${location.displayName}</h4>
+                                   
+                          <j:forEach var="backup" items="${location.availableBackups}">
+                            <f:radio name="backupHash" value="${backup.hashCode()}"/>
+                            ${backup.displayName}
+                            <br/>
+                            
+                            <j:set var="noBackups" value="false"/>
+                          </j:forEach>
+                        </div>
+                      </j:forEach> 
+                            
+                      <div>
+                        <j:if test="${noBackups == 'false'}">
+                          <f:submit value="${%restore.launch}"/>
+                        </j:if>
+                      </div>
+                            
+                    </f:form>
                 </j:otherwise>
             </j:choose>
         </l:main-panel>


### PR DESCRIPTION
Noticed it in my development environment. The plugin uses exotic table rendering, which effectively makes the submit button to appear outside the form. From what I see at some point the logic stopped handling it correctly.

I have just removed table from the Jelly file since it does not seem to be useful anymore in 1.609+

https://issues.jenkins-ci.org/browse/JENKINS-44997

New layout does not differ much from the original one:

![screen shot 2017-06-20 at 14 56 43](https://user-images.githubusercontent.com/3000480/27334486-c129b6f6-55c9-11e7-8709-edac3cb0b35d.png)

@reviewbybees @daniel-beck 