### PR TITLE
Fix regression in Util#listFiles() during the backup restoration.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/Util.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/Util.java
@@ -167,14 +167,20 @@ public class Util {
     
     /**
      * Secure version of the listFiles() logic
-     * @param directory Directory to be listed
+     * @param directory Directory to be listed       
      * @param fileFilter Optional file filter
-     * @return Files in the directory
+     * @return Files in the directory.
+     *         If the directory does not exist, an empty list will be returned
      * @throws PeriodicBackupException Whatever error
      */
     @Nonnull
     @Restricted(NoExternalUse.class)
     public static File[] listFiles(@Nonnull File directory, @CheckForNull FileFilter fileFilter) throws PeriodicBackupException {
+        if (!directory.exists()) {
+            // Not our business to check if the directory exists
+            return new File[0];
+        }
+        
         if (!directory.isDirectory()) {
             throw new PeriodicBackupException(formatMessage(directory, "File is not a directory"));
         }


### PR DESCRIPTION
I was able to test it after the [JENKINS-44997](https://issues.jenkins-ci.org/browse/JENKINS-44997) fix..

`File#listFiles()` returns empty list when the file does not exist.

But in my case I was getting Error due to the `isDirectory()` check (see https://github.com/jenkinsci/periodicbackup-plugin/pull/10 )

