### PR TITLE
Option to follow symbolic links in Full backup

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/FullBackup.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/FullBackup.java
@@ -52,14 +52,15 @@ public class FullBackup extends FileManager {
     @CheckForNull
     private final String excludesString;
 	private final File baseDir;
+	private final boolean followSymbolicLinks;
 
     public FullBackup() {
-        this(null);
+        this(null, false);
     }
 
     @DataBoundConstructor
-	public FullBackup(@CheckForNull String excludesString) {
-		this(excludesString, Jenkins.getActiveInstance().getRootDir());
+	public FullBackup(@CheckForNull String excludesString, boolean followSymbolicLinks) {
+		this(excludesString, followSymbolicLinks, Jenkins.getActiveInstance().getRootDir());
 	}
 
     /**
@@ -68,9 +69,10 @@ public class FullBackup extends FileManager {
      * @param excludesString Optional list of directories to be excluded
      * @param baseDir Base directory
      */
-    FullBackup(@CheckForNull String excludesString, @Nonnull File baseDir) {
+    FullBackup(@CheckForNull String excludesString, @CheckForNull boolean followSymbolicLinks, @Nonnull File baseDir) {
     	super();
     	this.excludesString = StringUtils.trimToNull(excludesString);
+        this.followSymbolicLinks = followSymbolicLinks;
 		this.baseDir = baseDir;
     	this.restorePolicy = new ReplaceRestorePolicy();
     }
@@ -83,7 +85,7 @@ public class FullBackup extends FileManager {
     @Override
     public Iterable<File> getFilesToBackup() {
         DirectoryScanner directoryScanner = new DirectoryScanner(); // It will scan all files inside the root directory
-        directoryScanner.setFollowSymlinks(false);
+        directoryScanner.setFollowSymlinks(followSymbolicLinks);
         directoryScanner.setBasedir(baseDir);
         directoryScanner.setExcludes(Iterables.toArray(getExcludes(), String.class));
         directoryScanner.scan();
@@ -119,6 +121,11 @@ public class FullBackup extends FileManager {
     @CheckForNull
     public String getExcludesString() {
         return excludesString;
+    }
+
+    @CheckForNull
+    public boolean isFollowSymbolicLinks() {
+        return followSymbolicLinks;
     }
 
     @SuppressWarnings("unused")

--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/FullBackup.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/FullBackup.java
@@ -69,7 +69,7 @@ public class FullBackup extends FileManager {
      * @param excludesString Optional list of directories to be excluded
      * @param baseDir Base directory
      */
-    FullBackup(@CheckForNull String excludesString, @CheckForNull boolean followSymbolicLinks, @Nonnull File baseDir) {
+    FullBackup(@CheckForNull String excludesString, boolean followSymbolicLinks, @Nonnull File baseDir) {
     	super();
     	this.excludesString = StringUtils.trimToNull(excludesString);
         this.followSymbolicLinks = followSymbolicLinks;
@@ -123,7 +123,6 @@ public class FullBackup extends FileManager {
         return excludesString;
     }
 
-    @CheckForNull
     public boolean isFollowSymbolicLinks() {
         return followSymbolicLinks;
     }

--- a/src/main/resources/org/jenkinsci/plugins/periodicbackup/FullBackup/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/periodicbackup/FullBackup/config.jelly
@@ -33,6 +33,10 @@
         <!-- This entry is only for help file binding -->
     </f:entry>
 
+    <f:entry title="${%followSymbolicLinks.title}" field="followSymbolicLinks">
+        <f:checkbox/>
+    </f:entry>
+
     <f:entry title="${%excludesString.title}" field="excludesString">
         <f:textbox/>
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/periodicbackup/FullBackup/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/periodicbackup/FullBackup/config.properties
@@ -1,2 +1,3 @@
 
 excludesString.title=Excludes list
+followSymbolicLinks.title=Follow symbolic links

--- a/src/main/resources/org/jenkinsci/plugins/periodicbackup/FullBackup/help-followSymbolicLinks.html
+++ b/src/main/resources/org/jenkinsci/plugins/periodicbackup/FullBackup/help-followSymbolicLinks.html
@@ -1,0 +1,3 @@
+<div>
+    Check this to follow all symbolic links within Jenkins home during full backup.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/periodicbackup/LocalDirectoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/periodicbackup/LocalDirectoryTest.java
@@ -24,7 +24,7 @@ public class LocalDirectoryTest extends HudsonTestCase {
         LocalDirectory localDirectory = new LocalDirectory(path, true);
         Date expectedDate = new Date(123);
         BackupObject expected = new BackupObject(
-                new FullBackup(""),
+                new FullBackup("", false),
                 new ZipStorage(false, 0),
                 new LocalDirectory(new File("c:\\Temp"), true),
                 expectedDate);
@@ -64,7 +64,7 @@ public class LocalDirectoryTest extends HudsonTestCase {
         File tempDirectory = new File(Thread.currentThread().getContextClassLoader().getResource("data/temp").getFile());
         Date testDate = new Date(123-(Calendar.getInstance().get(Calendar.ZONE_OFFSET)));
         LocalDirectory localDirectory = new LocalDirectory(sourceDir, true);
-        BackupObject backupObject = new BackupObject(new FullBackup(""), new ZipStorage(false, 0), localDirectory, testDate);
+        BackupObject backupObject = new BackupObject(new FullBackup("", false), new ZipStorage(false, 0), localDirectory, testDate);
 
         Iterable<File> result = localDirectory.retrieveBackupFromLocation(backupObject, tempDirectory);
         File expectedResult = new File(tempDirectory, Util.createFileName(Util.generateFileNameBase(testDate), "zip"));

--- a/src/test/java/org/jenkinsci/plugins/periodicbackup/UtilTest.java
+++ b/src/test/java/org/jenkinsci/plugins/periodicbackup/UtilTest.java
@@ -43,7 +43,7 @@ public class UtilTest extends TestCase {
     @Test
     public void testCreateBackupObjectFile() throws Exception {
         File tempDirectory = new File(Resources.getResource("data/temp").getFile());
-        BackupObject backupObject = new BackupObject(new FullBackup("", new File("")), new ZipStorage(false, 0), new LocalDirectory(tempDirectory, true), new Date());
+        BackupObject backupObject = new BackupObject(new FullBackup("", false, new File("")), new ZipStorage(false, 0), new LocalDirectory(tempDirectory, true), new Date());
         String fileNameBase = "backupfile";
 
         File result = Util.createBackupObjectFile(backupObject, tempDirectory.getAbsolutePath(), fileNameBase);

--- a/src/test/resources/test-basedir/soft-link-to-source.txt
+++ b/src/test/resources/test-basedir/soft-link-to-source.txt
@@ -1,0 +1,1 @@
+../test-link-dir/source.txt

--- a/src/test/resources/test-link-dir/source.txt
+++ b/src/test/resources/test-link-dir/source.txt
@@ -1,0 +1,1 @@
+You know nothing Jon Snow!


### PR DESCRIPTION
Adds a checkbox that enables "follow symlinks" in "Full backup" which fixes the issue https://github.com/emanuelez/hudson-periodicbackup/issues/1

If Jenkins home is a symlink to another directory, then backup would fail since code ignores symlinks. This PR adds an option that a user can select to follow symlinks. If this check box is enabled, then full backup will work even if Jenkins home is a symlink.

Related PR that disabled symlink : https://github.com/jenkinsci/periodicbackup-plugin/pull/9 . I think it's better to give the choice to the user to follow symlinks or not. While the default is still not to follow symlinks.