### PR TITLE
Feat: Add JCasC support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,32 @@
         </developer>
     </developers>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
+                <artifactId>snakeyaml-api</artifactId>
+                <version>1.29.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>jackson2-api</artifactId>
+                <version>2.12.4</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.main</groupId>
+                <artifactId>jenkins-test-harness</artifactId>
+                <version>2.71</version>
+            </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.13.2</version>
+            </dependency>
+        </dependencies>
+
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
@@ -70,6 +96,25 @@
             <artifactId>aws-java-sdk-ec2</artifactId>
             <version>1.12.70</version>
         </dependency>
+
+        <dependency>
+            <groupId>io.jenkins</groupId>
+            <artifactId>configuration-as-code</artifactId>
+            <version>${configuration-as-code.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.configuration-as-code</groupId>
+            <artifactId>test-harness</artifactId>
+            <version>${configuration-as-code.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>joda-time</groupId>
+                    <artifactId>joda-time</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <distributionManagement>
@@ -85,6 +130,7 @@
         <java.level>8</java.level>
 
         <slf4jVersion>1.7.26</slf4jVersion>
+        <configuration-as-code.version>1.51</configuration-as-code.version>
     </properties>
 
     <build>
@@ -111,7 +157,7 @@
             <version>3.6</version>
           </plugin>
         </plugins>
-        
+
     </build>
 
     <reporting>
@@ -188,6 +234,6 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-</project>  
-  
+</project>
+
 

--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/PeriodicBackupConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/PeriodicBackupConfigurator.java
@@ -1,0 +1,49 @@
+package org.jenkinsci.plugins.periodicbackup;
+
+import com.google.common.collect.ImmutableSet;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import io.jenkins.plugins.casc.BaseConfigurator;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorException;
+import io.jenkins.plugins.casc.RootElementConfigurator;
+import io.jenkins.plugins.casc.model.Mapping;
+import org.jenkinsci.Symbol;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import java.util.Set;
+
+@Extension(optional = true, ordinal = -50)
+@Restricted(NoExternalUse.class)
+@Symbol("periodicBackup")
+public class PeriodicBackupConfigurator extends BaseConfigurator<PeriodicBackupLink> implements RootElementConfigurator<PeriodicBackupLink> {
+
+
+    @Override
+    public PeriodicBackupLink getTargetComponent(ConfigurationContext context) {
+        return PeriodicBackupLink.get();
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "periodicBackup";
+    }
+
+    @Override
+    public Class<PeriodicBackupLink> getTarget() {
+        return PeriodicBackupLink.class;
+    }
+
+
+    protected Set<String> exclusions() {
+        return ImmutableSet.of("message", "backupNow");
+    }
+
+    @Override
+    protected PeriodicBackupLink instance(Mapping mapping, ConfigurationContext context) throws ConfiguratorException {
+        return PeriodicBackupLink.get();
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/periodicbackup/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/periodicbackup/ConfigurationAsCodeTest.java
@@ -1,0 +1,49 @@
+package org.jenkinsci.plugins.periodicbackup;
+
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import jenkins.model.Jenkins;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+public class ConfigurationAsCodeTest {
+    @Rule
+    public JenkinsConfiguredWithCodeRule r = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    @ConfiguredWithCode("jcasc/configuration-as-code.yml")
+
+
+    public void shouldSupportConfigurationAsCode() throws Exception {
+        PeriodicBackupLink target = Jenkins.get().getExtensionList(PeriodicBackupLink.class).get(0);
+        assertEquals("0 8 * * *", target.getCron());
+        assertEquals(7, target.getCycleDays());
+        assertEquals(7, target.getCycleQuantity());
+        assertEquals("/tmp", target.getTempDirectory());
+        assertTrue(target.getFileManagerPlugin() instanceof ConfigOnly);
+        assertEquals(3, target.getStorages().size());
+        assertTrue(target.getStorages().get(0) instanceof TarGzStorage);
+        assertTrue(target.getStorages().get(1) instanceof ZipStorage);
+        ZipStorage zip = (ZipStorage) target.getStorages().get(1);
+        assertTrue(zip.isMultiVolume());
+        assertEquals(16777216, zip.getVolumeSize());
+        assertEquals(2, target.getLocations().size());
+        assertTrue(target.getLocations().get(0) instanceof S3);
+        S3 s3 = (S3) target.getLocations().get(0);
+        assertEquals("bucket1", s3.getBucket());
+        assertTrue(s3.enabled);
+        assertEquals("prefix1", s3.getPrefix());
+        assertEquals("us-west-2", s3.getRegion());
+        assertEquals("/tmp/s3backup", s3.getTmpDir());
+        assertTrue(target.getLocations().get(1) instanceof LocalDirectory);
+        LocalDirectory localDirectory= (LocalDirectory) target.getLocations().get(1);
+        assertEquals("/var/jenkins/backup", localDirectory.getPath().getPath());
+        assertTrue(localDirectory.enabled);
+
+
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/periodicbackup/LocalDirectoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/periodicbackup/LocalDirectoryTest.java
@@ -3,8 +3,9 @@ package org.jenkinsci.plugins.periodicbackup;
 import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
 
+import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.File;
 import java.io.IOException;
@@ -12,12 +13,17 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 /**
  * Created by IntelliJ IDEA.
  * Author: tblaszcz
  * Date: 17-01-11
  */
-public class LocalDirectoryTest extends HudsonTestCase {
+public class LocalDirectoryTest {
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
     @Test
     public void testGetAvailableBackups() {
         File path = new File(Resources.getResource("data/").getFile());
@@ -51,8 +57,8 @@ public class LocalDirectoryTest extends HudsonTestCase {
         File[] filesInLocation = destination.listFiles();
         assertTrue(filesInLocation.length == 4);  //2 archives + backup object file + dummy == 4
 
-        for(File f : filesInLocation) {
-            if(!f.delete()) {
+        for (File f : filesInLocation) {
+            if (!f.delete()) {
                 throw new IOException("Could not delete file " + f.getAbsolutePath());
             }
         }

--- a/src/test/java/org/jenkinsci/plugins/periodicbackup/NullStorageTest.java
+++ b/src/test/java/org/jenkinsci/plugins/periodicbackup/NullStorageTest.java
@@ -4,25 +4,28 @@ import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.File;
-
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 /**
  * Created by IntelliJ IDEA.
  * Author: tblaszcz
  * Date: 15-04-11
  */
-public class NullStorageTest extends HudsonTestCase {
+public class NullStorageTest  {
 
     private String baseFileName;
     private File tempDirectory;
     private NullStorage nullStorage;
     private File archive1;
-
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
     @Before
     public void setUp() throws Exception {
-        super.setUp();
         baseFileName = "baseFileName";
         nullStorage = new NullStorage();
         tempDirectory = new File(Resources.getResource("data/temp2/").getFile());
@@ -34,6 +37,7 @@ public class NullStorageTest extends HudsonTestCase {
         archive1 = new File(Resources.getResource("data/archive1").getFile());
     }
 
+    @Test
     public void testBackupStop() throws Exception {
         File expectedResult = new File(tempDirectory, baseFileName + ".null");
         assertTrue(archive1.exists());
@@ -46,7 +50,7 @@ public class NullStorageTest extends HudsonTestCase {
         assertEquals(archives.iterator().next(), expectedResult);
 
     }
-
+    @Test
     public void testUnarchiveFiles() throws Exception {
         File sourceDir = new File(Resources.getResource("data/temp/").getFile());
         File newFile = new File(sourceDir, "newFile");

--- a/src/test/java/org/jenkinsci/plugins/periodicbackup/TarGzStorageTest.java
+++ b/src/test/java/org/jenkinsci/plugins/periodicbackup/TarGzStorageTest.java
@@ -1,16 +1,19 @@
-
 package org.jenkinsci.plugins.periodicbackup;
 
 import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 
 /**
@@ -19,20 +22,21 @@ import java.util.List;
  * Date: 14-04-11
  */
 
-public class TarGzStorageTest extends HudsonTestCase {
+public class TarGzStorageTest {
 
     private String baseFileName;
     private TarGzStorage tarGzStorage;
     private File tempDirectory;
     private File archive1;
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
 
     @Before
     public void setUp() throws Exception {
-        super.setUp();
         baseFileName = "baseFileName";
         tarGzStorage = new TarGzStorage();
         tempDirectory = new File(Resources.getResource("data/temp/").getFile());
-        if(tempDirectory.exists()) {
+        if (tempDirectory.exists()) {
             FileUtils.deleteDirectory(tempDirectory);
         }
         assertTrue(tempDirectory.mkdir());

--- a/src/test/java/org/jenkinsci/plugins/periodicbackup/UtilTest.java
+++ b/src/test/java/org/jenkinsci/plugins/periodicbackup/UtilTest.java
@@ -1,18 +1,21 @@
 package org.jenkinsci.plugins.periodicbackup;
 
 import com.google.common.io.Resources;
-import junit.framework.TestCase;
 import org.junit.Test;
 
 import java.io.File;
 import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 /**
  * Created by IntelliJ IDEA.
  * Author: tblaszcz
  * Date: 19-01-11
  */
-public class UtilTest extends TestCase {
+public class UtilTest  {
     @Test
     public void testGetRelativePath() throws Exception {
         File file = new File(Resources.getResource("data/temp/dummy").getFile());

--- a/src/test/java/org/jenkinsci/plugins/periodicbackup/ZipStorageTest.java
+++ b/src/test/java/org/jenkinsci/plugins/periodicbackup/ZipStorageTest.java
@@ -5,34 +5,38 @@ import com.google.common.io.Resources;
 import org.apache.commons.io.FileUtils;
 import org.codehaus.plexus.archiver.ArchiverException;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Created by IntelliJ IDEA.
  * Author: tblaszcz
  * Date: 19-01-11
  */
-public class ZipStorageTest extends HudsonTestCase {
+public class ZipStorageTest {
 
     private String baseFileName;
     private ZipStorage zipStorage;
     private File tempDirectory;
     private File archive1;
     private File archive2;
-
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
 
     @Before
     public void setUp() throws Exception {
-        super.setUp();
         baseFileName = "baseFileName";
         zipStorage = new ZipStorage(false, 0);
         tempDirectory = new File(Resources.getResource("data/temp2/").getFile());
-        if(tempDirectory.exists()) {
+        if (tempDirectory.exists()) {
             FileUtils.deleteDirectory(tempDirectory);
         }
         assertTrue(tempDirectory.mkdir());
@@ -70,7 +74,7 @@ public class ZipStorageTest extends HudsonTestCase {
 
         assertEquals(sizeBefore + 1, sizeAfter);
         assertEquals(filesInArchiveBefore + 1, filesInArchiveAfter);
-        assertEquals (sizeOfFilesInArchiveBefore + sizeOfTheFile, sizeOfFilesInArchiveAfter);
+        assertEquals(sizeOfFilesInArchiveBefore + sizeOfTheFile, sizeOfFilesInArchiveAfter);
 
         zipStorage.backupStop();
     }
@@ -86,7 +90,7 @@ public class ZipStorageTest extends HudsonTestCase {
 
         assertTrue(expectedResult.exists());
 
-        if(!expectedResult.delete()) {
+        if (!expectedResult.delete()) {
             throw new IOException("Could not delete file " + expectedResult.getAbsolutePath());
         }
     }

--- a/src/test/resources/jcasc/configuration-as-code.yml
+++ b/src/test/resources/jcasc/configuration-as-code.yml
@@ -1,0 +1,23 @@
+periodicBackup:
+  cron: "0 8 * * *"
+  cycleDays: 7
+  cycleQuantity: 7
+  fileManagerPlugin: "configOnly"
+  locations:
+    - s3:
+        bucket: "bucket1"
+        credentialsId: "aws-credentials"
+        enabled: true
+        prefix: "prefix1"
+        region: "us-west-2"
+        tmpDir: "/tmp/s3backup"
+    - localDirectory:
+        enabled: true
+        path: "/var/jenkins/backup"
+  storages:
+    - "tarGz"
+    - zip:
+        multiVolume: true
+        volumeSize: 16777216
+    - "null"
+  tempDirectory: "/tmp"


### PR DESCRIPTION
1. Add JCasC Configurator
2. Add JCasC test
3. Covert all tests to use Jenkins rule instead of HudsonTestCase
4. Upgrade snakeyaml-api and jackson2-api plugin version required by JCasC plugin

E2E test in an Jenkins instance

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
