### PR TITLE
feat: add support for includes list

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/periodicbackup/FullBackup.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicbackup/FullBackup.java
@@ -26,58 +26,64 @@ package org.jenkinsci.plugins.periodicbackup;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Splitter;
-import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import hudson.Extension;
-import org.apache.tools.ant.DirectoryScanner;
-import org.kohsuke.stapler.DataBoundConstructor;
-
 import java.io.File;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
+import org.apache.tools.ant.DirectoryScanner;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 
 /**
- *
  * FullBackup will choose all the files in the Jenkins homedir during the backup.
  * During the restore it will delete all the deletable files in the Jenkins homedir
  * and then it will write with files in the selected backup.
  */
 public class FullBackup extends FileManager {
-	
+    @CheckForNull
+    private final String includesString;
+
     @CheckForNull
     private final String excludesString;
-	private final File baseDir;
-	private final boolean followSymbolicLinks;
+    
+    private final File baseDir;
+    
+    private final boolean followSymbolicLinks;
 
     public FullBackup() {
-        this(null, false);
+        this(null, null, false);
     }
 
     @DataBoundConstructor
-	public FullBackup(@CheckForNull String excludesString, boolean followSymbolicLinks) {
-		this(excludesString, followSymbolicLinks, Jenkins.getActiveInstance().getRootDir());
-	}
+    public FullBackup(@CheckForNull String includesString, @CheckForNull String excludesString,
+            boolean followSymbolicLinks) {
+        this(includesString, excludesString, followSymbolicLinks, Jenkins.get().getRootDir());
+    }
 
     /**
-     * Test Constructor
-     * 
+     * Test Constructor.
+     *
+     * @param includesString Optional list of directories to be included
      * @param excludesString Optional list of directories to be excluded
      * @param baseDir Base directory
      */
-    FullBackup(@CheckForNull String excludesString, boolean followSymbolicLinks, @Nonnull File baseDir) {
-    	super();
-    	this.excludesString = StringUtils.trimToNull(excludesString);
+    FullBackup(@CheckForNull String includesString, @CheckForNull String excludesString,
+                boolean followSymbolicLinks, @Nonnull File baseDir) {
+        super();
+        this.includesString = StringUtils.trimToNull(includesString);
+        this.excludesString = StringUtils.trimToNull(excludesString);
         this.followSymbolicLinks = followSymbolicLinks;
-		this.baseDir = baseDir;
-    	this.restorePolicy = new ReplaceRestorePolicy();
+        this.baseDir = baseDir;
+        this.restorePolicy = new ReplaceRestorePolicy();
     }
-    
-    
+
     public String getDisplayName() {
         return "FullBackup";
     }
@@ -87,21 +93,31 @@ public class FullBackup extends FileManager {
         DirectoryScanner directoryScanner = new DirectoryScanner(); // It will scan all files inside the root directory
         directoryScanner.setFollowSymlinks(followSymbolicLinks);
         directoryScanner.setBasedir(baseDir);
-        directoryScanner.setExcludes(Iterables.toArray(getExcludes(), String.class));
+        directoryScanner.setIncludes(Iterators.toArray(getIncludes(), String.class));
+        directoryScanner.setExcludes(Iterators.toArray(getExcludes(), String.class));
         directoryScanner.scan();
         List<File> files = Lists.newArrayList();
         for (String s : directoryScanner.getIncludedFiles()) {
-          files.add(new File(directoryScanner.getBasedir(), s));
+            files.add(new File(directoryScanner.getBasedir(), s));
         }
         return files;
-      }
-    
-    private Iterable<String> getExcludes() {
-		if (this.excludesString == null) {
-			return Collections.emptyList();
-		}
-		return Lists.newArrayList(Splitter.on(';').trimResults().split(excludesString).iterator());
-	}
+    }
+
+    private Iterator<String> getIncludes() {
+        if (this.includesString == null) {
+            List<String> includes = Lists.newArrayList();
+            includes.add("**");
+            return includes.iterator();
+        }
+        return Splitter.on(';').trimResults().split(this.includesString).iterator();
+    }
+
+    private Iterator<String> getExcludes() {
+        if (this.excludesString == null) {
+            return Collections.emptyListIterator();
+        }
+        return Splitter.on(';').trimResults().split(this.excludesString).iterator();
+    }
 
     @Override
     public boolean equals(Object o) {
@@ -116,8 +132,13 @@ public class FullBackup extends FileManager {
     @Override
     public int hashCode() {
         return 73;
-    }	
-    
+    }
+
+    @CheckForNull
+    public String getIncludesString() {
+        return includesString;
+    }
+
     @CheckForNull
     public String getExcludesString() {
         return excludesString;

--- a/src/main/resources/org/jenkinsci/plugins/periodicbackup/FullBackup/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/periodicbackup/FullBackup/config.jelly
@@ -37,6 +37,10 @@
         <f:checkbox/>
     </f:entry>
 
+    <f:entry title="${%includesString.title}" field="includesString">
+        <f:textbox/>
+    </f:entry>
+
     <f:entry title="${%excludesString.title}" field="excludesString">
         <f:textbox/>
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/periodicbackup/FullBackup/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/periodicbackup/FullBackup/config.properties
@@ -1,3 +1,4 @@
 
-excludesString.title=Excludes list
 followSymbolicLinks.title=Follow symbolic links
+includesString.title=Includes list
+excludesString.title=Excludes list

--- a/src/main/resources/org/jenkinsci/plugins/periodicbackup/FullBackup/help-excludesString.html
+++ b/src/main/resources/org/jenkinsci/plugins/periodicbackup/FullBackup/help-excludesString.html
@@ -1,3 +1,3 @@
 <div>
-    A list of all excludes in ant syntax; separated by ';'.
+    A list of all excludes in Ant syntax; separated by ';'. Optional, if not specified no files will be excluded.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/periodicbackup/FullBackup/help-includesString.html
+++ b/src/main/resources/org/jenkinsci/plugins/periodicbackup/FullBackup/help-includesString.html
@@ -1,0 +1,3 @@
+<div>
+    A list of all includes in Ant syntax; separated by ';'. Optional, if not specified all files will be included.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/periodicbackup/LocalDirectoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/periodicbackup/LocalDirectoryTest.java
@@ -30,7 +30,7 @@ public class LocalDirectoryTest {
         LocalDirectory localDirectory = new LocalDirectory(path, true);
         Date expectedDate = new Date(123);
         BackupObject expected = new BackupObject(
-                new FullBackup("", false),
+                new FullBackup("", "", false),
                 new ZipStorage(false, 0),
                 new LocalDirectory(new File("c:\\Temp"), true),
                 expectedDate);
@@ -70,7 +70,7 @@ public class LocalDirectoryTest {
         File tempDirectory = new File(Thread.currentThread().getContextClassLoader().getResource("data/temp").getFile());
         Date testDate = new Date(123-(Calendar.getInstance().get(Calendar.ZONE_OFFSET)));
         LocalDirectory localDirectory = new LocalDirectory(sourceDir, true);
-        BackupObject backupObject = new BackupObject(new FullBackup("", false), new ZipStorage(false, 0), localDirectory, testDate);
+        BackupObject backupObject = new BackupObject(new FullBackup("", "", false), new ZipStorage(false, 0), localDirectory, testDate);
 
         Iterable<File> result = localDirectory.retrieveBackupFromLocation(backupObject, tempDirectory);
         File expectedResult = new File(tempDirectory, Util.createFileName(Util.generateFileNameBase(testDate), "zip"));

--- a/src/test/java/org/jenkinsci/plugins/periodicbackup/UtilTest.java
+++ b/src/test/java/org/jenkinsci/plugins/periodicbackup/UtilTest.java
@@ -46,7 +46,7 @@ public class UtilTest  {
     @Test
     public void testCreateBackupObjectFile() throws Exception {
         File tempDirectory = new File(Resources.getResource("data/temp").getFile());
-        BackupObject backupObject = new BackupObject(new FullBackup("", false, new File("")), new ZipStorage(false, 0), new LocalDirectory(tempDirectory, true), new Date());
+        BackupObject backupObject = new BackupObject(new FullBackup("", "", false, new File("")), new ZipStorage(false, 0), new LocalDirectory(tempDirectory, true), new Date());
         String fileNameBase = "backupfile";
 
         File result = Util.createBackupObjectFile(backupObject, tempDirectory.getAbsolutePath(), fileNameBase);


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Plugin support for exclusion lists is useful to limit what is included in a backup. However, it's difficult to exclude all files except for a few (for example, backing up only the `jobs` directory). Also supporting inclusion lists simplifies these kind of flows. Also, both lists can be combined to filter with greater granularity the set of copied files (_e.g._ copy all files in `jobs` directory except for archived artifacts).

The default configuration (both lists empty) does not modify the existing behaviour of backuping all files. Also, only configuring the list of excludes works as expected, so no breaking changes are added.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->